### PR TITLE
dynamic_PRODUCT_ID_TCS3000_targets

### DIFF
--- a/dispenser/TCS3000.ts
+++ b/dispenser/TCS3000.ts
@@ -98,7 +98,12 @@ export class TCS3000 extends BaseDispenser {
 	async sendPreset(quantity: number) {
 		let crc = 0;
 		const buffer_array = [];
-		const volumePrecursor = [0x7e, 0x01, 0x00, 0x20, 0x38, 0x0b, 0x03, 0x03, 0xf7];
+		
+		// Use TCS Product ID from options or fallback to environment variable or default
+		const tcsProductId = this.options?.tcsProductId || process.env.VITE_TCS_PROD_ID || '0x03,0xf7';
+		const prodIdBytes = tcsProductId.split(',').map((id: string) => parseInt(id.trim(), 16));
+		
+		const volumePrecursor = [0x7e, 0x01, 0x00, 0x20, 0x38, 0x0b, 0x03, prodIdBytes[0], prodIdBytes[1]];
 
 		// Calculate partial CRC for the precursor
 		for (const byte of volumePrecursor) {

--- a/dispenser/interface/IDispenser.ts
+++ b/dispenser/interface/IDispenser.ts
@@ -18,6 +18,7 @@ export interface IDispenser {
 	elockLock?(): any;
 	totalizer?(): any;
 	readStatus?(): any;
+	read_prod_ID?(): any;
 	pumpStart?(): any;
 	pumpStop?(): any;
 	hasExternalPump?(): any;
@@ -78,6 +79,7 @@ export type DispenserOptions = {
 	modbus?: ModbusOptions;
 	totalizerFile?: string;
 	interByteTimeoutInterval?: number;
+	tcsProductId?: string;
 };
 
 export type ModbusOptions = {

--- a/main.ts
+++ b/main.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { findDispenserPort } from './utils/findDispenserPort';
 import { findRfidPort } from './utils/findRfidPort';
 import { DispenserOptions, IDispenser } from './dispenser/interface/IDispenser';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@fuelbuddy/dispenser-sdk",
+  "name": "@fuelbuddy/dispenser-sdk-test",
   "version": "0.1.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@fuelbuddy/dispenser-sdk",
+      "name": "@fuelbuddy/dispenser-sdk-test",
       "version": "0.1.92",
       "license": "ISC",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@fuelbuddy/dispenser-sdk-test",
+  "name": "dispenser-sdk-test",
   "version": "0.1.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@fuelbuddy/dispenser-sdk-test",
+      "name": "dispenser-sdk-test",
       "version": "0.1.92",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fuelbuddy/dispenser-sdk",
+  "name": "@fuelbuddy/dispenser-sdk-test",
   "version": "0.1.92",
   "description": "",
   "main": "dist/main.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fuelbuddy/dispenser-sdk-test",
+  "name": "dispenser-sdk-test",
   "version": "0.1.92",
   "description": "",
   "main": "dist/main.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dispenser-sdk-test",
+  "name": "@fuelbuddy/dispenser-sdk",
   "version": "0.1.92",
   "description": "",
   "main": "dist/main.js",

--- a/tests/TCS3000.test.ts
+++ b/tests/TCS3000.test.ts
@@ -26,6 +26,7 @@ describe('TCS3000', () => {
 				attributeId,
 				baudRate: 9600,
 				kFactor: 3692953.6,
+                tcsProductId: '0x03,0xf7'
 			});
         }
     });

--- a/utils/envParser.ts
+++ b/utils/envParser.ts
@@ -15,6 +15,10 @@ export function getConfigFromEnv() {
 		dispenserConfig.kFactor = Number(process.env.VITE_MAIN_DISPENSER_K_FACTOR);
 	}
 
+	if (process.env.VITE_TCS_PROD_ID) {
+		dispenserConfig.tcsProductId = process.env.VITE_TCS_PROD_ID;
+	}
+
 	if (process.env.VITE_MAIN_PRINTER_TYPE) {
 		dispenserConfig.printer = {
 			printerType: process.env.VITE_MAIN_PRINTER_TYPE,


### PR DESCRIPTION
Added provision of dynamic PRODUCT_ID for CAFU trucks. 

Add a Environment Variable by name of VITE_TCS_PROD_ID= '0x99, 0x99' 