### PR TITLE
NO_T handle duplicate response in processStatus

### DIFF
--- a/dispenser/TCS3000.ts
+++ b/dispenser/TCS3000.ts
@@ -98,7 +98,7 @@ export class TCS3000 extends BaseDispenser {
 	getProductIDBytes() {
 		debugLog('TCS3000 constructor options: %O', this.options, process.env.VITE_TCS_PROD_ID);
 		// Parse the product ID string into a base-10 integer
-		
+
 		const productId = this.options.tcsProductId || 1015;
 
 		// Validate the parsed product ID
@@ -278,7 +278,17 @@ export class TCS3000 extends BaseDispenser {
 
 	processStatus(res: string) {
 		debugLog('processStatus: %s', res);
-		const statusBit = res.slice(16, -2);
+
+		// Handle duplicate response pattern
+		// Normal response: 7e0001c71f030061065c (20 chars)
+		// Duplicate response: 7e0001c71f030061065c7e0001c71f030061065c (40 chars)
+		let cleanRes = res;
+		if (res.length === 40) {
+			cleanRes = res.slice(20, 40);
+			debugLog('processStatus: Duplicate response detected, using second half: %s', cleanRes);
+		}
+
+		const statusBit = cleanRes.slice(16, -2);
 		const statusMap = new Map([
 			['00', 'ERROR'],
 			['01', 'IDLE'],


### PR DESCRIPTION
**Modified the processStatus method in dispenser/TCS3000.ts to:**
  1. Detect when a 40-character duplicate response is received
  2. Extract the valid response from the second half of the duplicate
  3. Process the cleaned response normally to extract the correct status bit
  4. Added debug logging to track when duplicate responses are detected

**Testing**
  - The fix ensures status codes are correctly extracted even when duplicate responses occur
  - Debug logging helps monitor and track the frequency of duplicate responses
  - No changes to external API or method signatures